### PR TITLE
Use float32 to describe metrics, not ints

### DIFF
--- a/g2s.go
+++ b/g2s.go
@@ -13,7 +13,7 @@ const (
 )
 
 type Statter interface {
-	Counter(sampleRate float32, bucket string, n ...int)
+	Counter(sampleRate float32, bucket string, n ...float32)
 	Timing(sampleRate float32, bucket string, d ...time.Duration)
 	Gauge(sampleRate float32, bucket string, value ...string)
 }
@@ -116,7 +116,7 @@ func maybeSample(r float32) (sampling, bool) {
 // Application code should call it for every potential invocation of a
 // statistic; it uses the sampleRate to determine whether or not to send or
 // squelch the data, on an aggregate basis.
-func (s *statsd) Counter(sampleRate float32, bucket string, n ...int) {
+func (s *statsd) Counter(sampleRate float32, bucket string, n ...float32) {
 	samp, ok := maybeSample(sampleRate)
 	if !ok {
 		return
@@ -149,7 +149,7 @@ func (s *statsd) Timing(sampleRate float32, bucket string, d ...time.Duration) {
 	for i, di := range d {
 		msgs[i] = &timingUpdate{
 			bucket:   bucket,
-			ms:       int(di.Nanoseconds() / 1e6),
+			ms:       float32(float64(di) / float64(time.Millisecond)),
 			sampling: samp,
 		}
 	}

--- a/g2s_test.go
+++ b/g2s_test.go
@@ -18,8 +18,8 @@ func TestCounter(t *testing.T) {
 
 	s.Counter(1.0, "gorets", 1)
 
-	if expected, got := "gorets:1|c", b.String(); expected != got {
-		t.Errorf("expected %q, got %q", expected, got)
+	if expected, got := "gorets:1.000000|c", b.String(); expected != got {
+		t.Errorf("expected '%s', got '%s'", expected, got)
 	}
 }
 
@@ -32,8 +32,8 @@ func TestTiming(t *testing.T) {
 
 	s.Timing(1.0, "glork", 320*time.Millisecond)
 
-	if expected, got := "glork:320|ms", b.String(); expected != got {
-		t.Errorf("expected %q, got %q", expected, got)
+	if expected, got := "glork:320.000000|ms", b.String(); expected != got {
+		t.Errorf("expected '%s', got '%s'", expected, got)
 	}
 }
 
@@ -47,7 +47,7 @@ func TestGauge(t *testing.T) {
 	s.Gauge(1.0, "gaugor", "333")
 
 	if expected, got := "gaugor:333|g", b.String(); expected != got {
-		t.Errorf("expected %q, got %q", expected, got)
+		t.Errorf("expected '%s', got '%s'", expected, got)
 	}
 }
 
@@ -61,10 +61,10 @@ func TestMany(t *testing.T) {
 	s.Counter(1.0, "foo", 1, 2, 3)
 	s.Timing(1.0, "bar", 4*time.Millisecond, 5*time.Millisecond)
 
-	expected := "foo:1|c\nfoo:2|c\nfoo:3|cbar:4|ms\nbar:5|ms"
+	expected := "foo:1.000000|c\nfoo:2.000000|c\nfoo:3.000000|cbar:4.000000|ms\nbar:5.000000|ms"
 	got := b.String()
 	if expected != got {
-		t.Errorf("expected %q, got %q", expected, got)
+		t.Errorf("expected '%s', got '%s'", expected, got)
 	}
 }
 
@@ -78,7 +78,7 @@ func TestSamplingZero(t *testing.T) {
 	s.Counter(0.0, "nobucket", 1) // should never succeed
 
 	if expected, got := "", b.String(); expected != got {
-		t.Errorf("expected %q, got %q", expected, got)
+		t.Errorf("expected '%s', got '%s'", expected, got)
 	}
 }
 

--- a/safe.go
+++ b/safe.go
@@ -6,7 +6,7 @@ import (
 
 type noStatsd struct{}
 
-func (n noStatsd) Counter(float32, string, ...int)          {}
+func (n noStatsd) Counter(float32, string, ...float32)      {}
 func (n noStatsd) Timing(float32, string, ...time.Duration) {}
 func (n noStatsd) Gauge(float32, string, ...string)         {}
 

--- a/types.go
+++ b/types.go
@@ -22,22 +22,22 @@ func (s *sampling) Suffix() string {
 
 type counterUpdate struct {
 	bucket string
-	n      int
+	n      float32
 	sampling
 }
 
 func (u *counterUpdate) Message() string {
-	return fmt.Sprintf("%s:%d|c%s\n", u.bucket, u.n, u.sampling.Suffix())
+	return fmt.Sprintf("%s:%f|c%s\n", u.bucket, u.n, u.sampling.Suffix())
 }
 
 type timingUpdate struct {
 	bucket string
-	ms     int
+	ms     float32
 	sampling
 }
 
 func (u *timingUpdate) Message() string {
-	return fmt.Sprintf("%s:%d|ms\n", u.bucket, u.ms)
+	return fmt.Sprintf("%s:%f|ms\n", u.bucket, u.ms)
 }
 
 type gaugeUpdate struct {


### PR DESCRIPTION
this allows a greater precision when the value is very small
e.g. when measuring operations that take less than 1 millisecond
